### PR TITLE
WIP: Variants iOS implementation

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,15 @@
+.DS_Store
+
+*.pbxuser
+*.perspective
+*.perspectivev3
+
+*.mode1v3
+*.mode2v3
+
+*.xcodeproj/xcuserdata/*.xcuserdatad
+
+*.xccheckout
+*.xcuserdatad
+
+build/

--- a/ios/Variants.xcodeproj/project.pbxproj
+++ b/ios/Variants.xcodeproj/project.pbxproj
@@ -1,0 +1,435 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		8D6599821A4375540001F335 /* libVariants.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D6599761A4375530001F335 /* libVariants.a */; };
+		8D6599911A4377490001F335 /* VariantsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D6599901A4377490001F335 /* VariantsTest.m */; };
+		8D6599981A437A6B0001F335 /* Registry.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D6599971A437A6B0001F335 /* Registry.m */; };
+		8D6599991A437A6B0001F335 /* Registry.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D6599971A437A6B0001F335 /* Registry.m */; };
+		8D65999C1A437CDC0001F335 /* Flag.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D65999B1A437CDC0001F335 /* Flag.m */; };
+		8D65999D1A437CDC0001F335 /* Flag.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D65999B1A437CDC0001F335 /* Flag.m */; };
+		8D6599A01A4395AF0001F335 /* Mod.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D65999F1A4395AF0001F335 /* Mod.m */; };
+		8D6599A11A4395AF0001F335 /* Mod.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D65999F1A4395AF0001F335 /* Mod.m */; };
+		8D6599A41A4397190001F335 /* Condition.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D6599A31A4397190001F335 /* Condition.m */; };
+		8D6599A51A4397190001F335 /* Condition.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D6599A31A4397190001F335 /* Condition.m */; };
+		8D6599A81A43ACA80001F335 /* Variant.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D6599A71A43ACA80001F335 /* Variant.m */; };
+		8D6599A91A43ACA80001F335 /* Variant.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D6599A71A43ACA80001F335 /* Variant.m */; };
+		8D6599B01A45C6280001F335 /* altdata.json in Resources */ = {isa = PBXBuildFile; fileRef = 8D6599AA1A45C6280001F335 /* altdata.json */; };
+		8D6599B11A45C6280001F335 /* broken_nocondition.json in Resources */ = {isa = PBXBuildFile; fileRef = 8D6599AB1A45C6280001F335 /* broken_nocondition.json */; };
+		8D6599B21A45C6280001F335 /* broken_nooperator.json in Resources */ = {isa = PBXBuildFile; fileRef = 8D6599AC1A45C6280001F335 /* broken_nooperator.json */; };
+		8D6599B31A45C6280001F335 /* custom.json in Resources */ = {isa = PBXBuildFile; fileRef = 8D6599AD1A45C6280001F335 /* custom.json */; };
+		8D6599B41A45C6280001F335 /* testdata_reloaded.json in Resources */ = {isa = PBXBuildFile; fileRef = 8D6599AE1A45C6280001F335 /* testdata_reloaded.json */; };
+		8D6599B51A45C6280001F335 /* testdata.json in Resources */ = {isa = PBXBuildFile; fileRef = 8D6599AF1A45C6280001F335 /* testdata.json */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		8D6599831A4375540001F335 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8D65996E1A4375530001F335 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8D6599751A4375530001F335;
+			remoteInfo = Variants;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		8D6599741A4375530001F335 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		8D6599761A4375530001F335 /* libVariants.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libVariants.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8D6599811A4375540001F335 /* VariantsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VariantsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8D6599871A4375540001F335 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8D6599901A4377490001F335 /* VariantsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VariantsTest.m; sourceTree = "<group>"; };
+		8D6599961A437A6B0001F335 /* Registry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Registry.h; sourceTree = "<group>"; };
+		8D6599971A437A6B0001F335 /* Registry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Registry.m; sourceTree = "<group>"; };
+		8D65999A1A437CDC0001F335 /* Flag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Flag.h; sourceTree = "<group>"; };
+		8D65999B1A437CDC0001F335 /* Flag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Flag.m; sourceTree = "<group>"; };
+		8D65999E1A4395AF0001F335 /* Mod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Mod.h; sourceTree = "<group>"; };
+		8D65999F1A4395AF0001F335 /* Mod.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Mod.m; sourceTree = "<group>"; };
+		8D6599A21A4397190001F335 /* Condition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Condition.h; sourceTree = "<group>"; };
+		8D6599A31A4397190001F335 /* Condition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Condition.m; sourceTree = "<group>"; };
+		8D6599A61A43ACA80001F335 /* Variant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Variant.h; sourceTree = "<group>"; };
+		8D6599A71A43ACA80001F335 /* Variant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Variant.m; sourceTree = "<group>"; };
+		8D6599AA1A45C6280001F335 /* altdata.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = altdata.json; sourceTree = "<group>"; };
+		8D6599AB1A45C6280001F335 /* broken_nocondition.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = broken_nocondition.json; sourceTree = "<group>"; };
+		8D6599AC1A45C6280001F335 /* broken_nooperator.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = broken_nooperator.json; sourceTree = "<group>"; };
+		8D6599AD1A45C6280001F335 /* custom.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = custom.json; sourceTree = "<group>"; };
+		8D6599AE1A45C6280001F335 /* testdata_reloaded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = testdata_reloaded.json; sourceTree = "<group>"; };
+		8D6599AF1A45C6280001F335 /* testdata.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = testdata.json; sourceTree = "<group>"; };
+		8D6599B61A45CD4E0001F335 /* Registry+Testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Registry+Testing.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8D6599731A4375530001F335 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8D65997E1A4375540001F335 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8D6599821A4375540001F335 /* libVariants.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		8D65996D1A4375530001F335 = {
+			isa = PBXGroup;
+			children = (
+				8D6599781A4375540001F335 /* Variants */,
+				8D6599851A4375540001F335 /* VariantsTests */,
+				8D6599771A4375540001F335 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		8D6599771A4375540001F335 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8D6599761A4375530001F335 /* libVariants.a */,
+				8D6599811A4375540001F335 /* VariantsTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8D6599781A4375540001F335 /* Variants */ = {
+			isa = PBXGroup;
+			children = (
+				8D6599961A437A6B0001F335 /* Registry.h */,
+				8D6599971A437A6B0001F335 /* Registry.m */,
+				8D6599B61A45CD4E0001F335 /* Registry+Testing.h */,
+				8D65999A1A437CDC0001F335 /* Flag.h */,
+				8D65999B1A437CDC0001F335 /* Flag.m */,
+				8D65999E1A4395AF0001F335 /* Mod.h */,
+				8D65999F1A4395AF0001F335 /* Mod.m */,
+				8D6599A21A4397190001F335 /* Condition.h */,
+				8D6599A31A4397190001F335 /* Condition.m */,
+				8D6599A61A43ACA80001F335 /* Variant.h */,
+				8D6599A71A43ACA80001F335 /* Variant.m */,
+			);
+			path = Variants;
+			sourceTree = "<group>";
+		};
+		8D6599851A4375540001F335 /* VariantsTests */ = {
+			isa = PBXGroup;
+			children = (
+				8D6599861A4375540001F335 /* Supporting Files */,
+				8D6599901A4377490001F335 /* VariantsTest.m */,
+			);
+			path = VariantsTests;
+			sourceTree = "<group>";
+		};
+		8D6599861A4375540001F335 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				8D6599AA1A45C6280001F335 /* altdata.json */,
+				8D6599AB1A45C6280001F335 /* broken_nocondition.json */,
+				8D6599AC1A45C6280001F335 /* broken_nooperator.json */,
+				8D6599AD1A45C6280001F335 /* custom.json */,
+				8D6599AE1A45C6280001F335 /* testdata_reloaded.json */,
+				8D6599AF1A45C6280001F335 /* testdata.json */,
+				8D6599871A4375540001F335 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		8D6599751A4375530001F335 /* Variants */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8D65998A1A4375540001F335 /* Build configuration list for PBXNativeTarget "Variants" */;
+			buildPhases = (
+				8D6599721A4375530001F335 /* Sources */,
+				8D6599731A4375530001F335 /* Frameworks */,
+				8D6599741A4375530001F335 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Variants;
+			productName = Variants;
+			productReference = 8D6599761A4375530001F335 /* libVariants.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		8D6599801A4375540001F335 /* VariantsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8D65998D1A4375540001F335 /* Build configuration list for PBXNativeTarget "VariantsTests" */;
+			buildPhases = (
+				8D65997D1A4375540001F335 /* Sources */,
+				8D65997E1A4375540001F335 /* Frameworks */,
+				8D65997F1A4375540001F335 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8D6599841A4375540001F335 /* PBXTargetDependency */,
+			);
+			name = VariantsTests;
+			productName = VariantsTests;
+			productReference = 8D6599811A4375540001F335 /* VariantsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		8D65996E1A4375530001F335 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+				ORGANIZATIONNAME = "Andrew Bonventre";
+				TargetAttributes = {
+					8D6599751A4375530001F335 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+					8D6599801A4375540001F335 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 8D6599711A4375530001F335 /* Build configuration list for PBXProject "Variants" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 8D65996D1A4375530001F335;
+			productRefGroup = 8D6599771A4375540001F335 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8D6599751A4375530001F335 /* Variants */,
+				8D6599801A4375540001F335 /* VariantsTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		8D65997F1A4375540001F335 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8D6599B01A45C6280001F335 /* altdata.json in Resources */,
+				8D6599B11A45C6280001F335 /* broken_nocondition.json in Resources */,
+				8D6599B31A45C6280001F335 /* custom.json in Resources */,
+				8D6599B21A45C6280001F335 /* broken_nooperator.json in Resources */,
+				8D6599B41A45C6280001F335 /* testdata_reloaded.json in Resources */,
+				8D6599B51A45C6280001F335 /* testdata.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8D6599721A4375530001F335 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8D6599A01A4395AF0001F335 /* Mod.m in Sources */,
+				8D6599981A437A6B0001F335 /* Registry.m in Sources */,
+				8D65999C1A437CDC0001F335 /* Flag.m in Sources */,
+				8D6599A41A4397190001F335 /* Condition.m in Sources */,
+				8D6599A81A43ACA80001F335 /* Variant.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8D65997D1A4375540001F335 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8D6599911A4377490001F335 /* VariantsTest.m in Sources */,
+				8D6599991A437A6B0001F335 /* Registry.m in Sources */,
+				8D6599A11A4395AF0001F335 /* Mod.m in Sources */,
+				8D65999D1A437CDC0001F335 /* Flag.m in Sources */,
+				8D6599A91A43ACA80001F335 /* Variant.m in Sources */,
+				8D6599A51A4397190001F335 /* Condition.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		8D6599841A4375540001F335 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8D6599751A4375530001F335 /* Variants */;
+			targetProxy = 8D6599831A4375540001F335 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		8D6599881A4375540001F335 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		8D6599891A4375540001F335 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		8D65998B1A4375540001F335 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		8D65998C1A4375540001F335 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		8D65998E1A4375540001F335 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = VariantsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		8D65998F1A4375540001F335 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = VariantsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		8D6599711A4375530001F335 /* Build configuration list for PBXProject "Variants" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8D6599881A4375540001F335 /* Debug */,
+				8D6599891A4375540001F335 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8D65998A1A4375540001F335 /* Build configuration list for PBXNativeTarget "Variants" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8D65998B1A4375540001F335 /* Debug */,
+				8D65998C1A4375540001F335 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8D65998D1A4375540001F335 /* Build configuration list for PBXNativeTarget "VariantsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8D65998E1A4375540001F335 /* Debug */,
+				8D65998F1A4375540001F335 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 8D65996E1A4375530001F335 /* Project object */;
+}

--- a/ios/Variants.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/Variants.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Variants.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ios/Variants/Condition.h
+++ b/ios/Variants/Condition.h
@@ -1,0 +1,20 @@
+//
+//  Condition.h
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/18/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef BOOL (^ConditionEvaluator)(id<NSCopying>);
+typedef ConditionEvaluator (^ConditionSpec)(id<NSCopying>);
+
+@interface Condition : NSObject
+
+- (instancetype)initWithEvaluationBlock:(ConditionEvaluator)block;
+
+@property(nonatomic, copy, readonly) BOOL (^evaluationBlock)(id<NSCopying>);
+
+@end

--- a/ios/Variants/Condition.m
+++ b/ios/Variants/Condition.m
@@ -1,0 +1,23 @@
+//
+//  Condition.m
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/18/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+#import "Condition.h"
+
+@implementation Condition
+
+- (instancetype)initWithEvaluationBlock:(ConditionEvaluator)block {
+  self = [super init];
+  if (self) {
+    _evaluationBlock = [^BOOL(id<NSCopying> outerContext) {
+        return block([outerContext copyWithZone:NULL]);
+    } copy];
+  }
+  return self;
+}
+
+@end

--- a/ios/Variants/Flag.h
+++ b/ios/Variants/Flag.h
@@ -1,0 +1,23 @@
+//
+//  Flag.h
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/18/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface Flag : NSObject
+
+- (instancetype)initWithName:(NSString *)name
+                 description:(NSString *)description
+                   baseValue:(id<NSCopying>)baseValue;
+
++ (instancetype)flagFromDictionary:(NSDictionary *)dictionary;
+
+@property(nonatomic, copy, readonly) NSString *name;
+@property(nonatomic, copy, readonly) NSString *flagDescription;
+@property(nonatomic, copy, readonly) id baseValue;
+
+@end

--- a/ios/Variants/Flag.m
+++ b/ios/Variants/Flag.m
@@ -1,0 +1,31 @@
+//
+//  Flag.m
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/18/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+#import "Flag.h"
+
+@implementation Flag
+
+- (instancetype)initWithName:(NSString *)name
+                 description:(NSString *)description
+                   baseValue:(id<NSCopying>)baseValue {
+  self = [super init];
+  if (self) {
+    _name = [name copy];
+    _flagDescription = [description copy];
+    _baseValue = [baseValue copyWithZone:NULL];
+  }
+  return self;
+}
+
++ (instancetype)flagFromDictionary:(NSDictionary *)dictionary {
+  return [[Flag alloc] initWithName:dictionary[@"flag"]
+                        description:dictionary[@"desc"]
+                          baseValue:dictionary[@"base_value"]];
+}
+
+@end

--- a/ios/Variants/Mod.h
+++ b/ios/Variants/Mod.h
@@ -1,0 +1,21 @@
+//
+//  Mod.h
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/18/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface Mod : NSObject
+
+- (instancetype)initWithFlagName:(NSString *)flagName
+                           value:(id<NSCopying>)value;
+
++ (instancetype)modFromDictionary:(NSDictionary *)dictionary;
+
+@property(nonatomic, copy, readonly) NSString *flagName;
+@property(nonatomic, copy, readonly) id value;
+
+@end

--- a/ios/Variants/Mod.m
+++ b/ios/Variants/Mod.m
@@ -1,0 +1,28 @@
+//
+//  Mod.m
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/18/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+#import "Mod.h"
+
+@implementation Mod
+
+- (instancetype)initWithFlagName:(NSString *)flagName
+                           value:(id<NSCopying>)value {
+  self = [super init];
+  if (self) {
+    _flagName = [flagName copy];
+    _value = [value copyWithZone:NULL];
+  }
+  return self;
+}
+
++ (instancetype)modFromDictionary:(NSDictionary *)dictionary {
+  return [[Mod alloc] initWithFlagName:dictionary[@"flag"]
+                                 value:dictionary[@"value"]];
+}
+
+@end

--- a/ios/Variants/Registry+Testing.h
+++ b/ios/Variants/Registry+Testing.h
@@ -1,0 +1,11 @@
+//
+//  Registry+Testing.h
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/20/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+@interface Registry (Testing)
++ (void)_setSharedRegistry:(Registry *)registry;
+@end

--- a/ios/Variants/Registry.h
+++ b/ios/Variants/Registry.h
@@ -1,0 +1,29 @@
+//
+//  Registry.h
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/18/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "Condition.h"
+
+@class Flag;
+@class Variant;
+
+@interface Registry : NSObject
+
++ (instancetype)sharedRegistry;
+- (void)addFlag:(Flag *)flag;
+- (id)flagValueWithName:(NSString *)name;
+- (id)flagValueWithName:(NSString *)name context:(id<NSCopying>)context;
+- (NSArray *)allFlags;
+- (void)addVariant:(Variant *)variant;
+- (NSArray *)allVariants;
+- (void)registerConditionTypeWithId:(NSString *)identifier
+                          specBlock:(ConditionSpec)specBlock;
+- (void)loadConfigFromData:(NSData *)data error:(NSError **)error;
+- (void)loadConfigFromDictionary:(NSDictionary *)dictionary;
+@end

--- a/ios/Variants/Registry.m
+++ b/ios/Variants/Registry.m
@@ -1,0 +1,232 @@
+//
+//  Registry.m
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/18/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+#import "Registry.h"
+
+#import "Condition.h"
+#import "Flag.h"
+#import "Mod.h"
+#import "Variant.h"
+
+@interface Registry ()
+- (void)_registerBuiltInConditionTypes;
+- (Variant *)_variantFromDictionary:(NSDictionary *)dictionary;
+
+@property(nonatomic, strong) NSMutableDictionary *variantIdToVariant;
+@property(nonatomic, strong) NSMutableDictionary *conditionTypeToSpecBlock;
+@property(nonatomic, strong) NSMutableDictionary *flagNameToFlag;
+@property(nonatomic, strong) NSMutableDictionary *flagNameToVariantIdSet;
+@end
+
+@implementation Registry
+
+static dispatch_once_t onceToken;
+static Registry *_sharedRegistry = nil;
+
++ (instancetype)sharedRegistry {
+  dispatch_once(&onceToken, ^{ _sharedRegistry = [[Registry alloc] init]; });
+  return _sharedRegistry;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _variantIdToVariant = [NSMutableDictionary dictionary];
+    _conditionTypeToSpecBlock = [NSMutableDictionary dictionary];
+    _flagNameToFlag = [NSMutableDictionary dictionary];
+    _flagNameToVariantIdSet = [NSMutableDictionary dictionary];
+
+    [self _registerBuiltInConditionTypes];
+  }
+  return self;
+}
+
+- (void)addFlag:(Flag *)flag {
+  if (self.flagNameToFlag[flag.name]) {
+    [NSException
+         raise:@"Flag has already been added"
+        format:@"A Flag with the name %@ has already been added", flag.name];
+  }
+  self.flagNameToFlag[flag.name] = flag;
+  self.flagNameToVariantIdSet[flag.name] = [NSMutableSet set];
+}
+
+- (id)flagValueWithName:(NSString *)name {
+  return [self flagValueWithName:name context:nil];
+}
+
+- (id)flagValueWithName:(NSString *)name context:(id<NSCopying>)context {
+  id value = [(Flag *)self.flagNameToFlag[name] baseValue];
+  for (NSString *variantId in self.flagNameToVariantIdSet[name]) {
+    Variant *v = self.variantIdToVariant[variantId];
+    if ([v evaluateWithContext:context]) {
+      value = [v valueForFlagWithName:name];
+    }
+  }
+  return value;
+}
+
+- (NSArray *)allFlags {
+  return [self.flagNameToFlag allKeys];
+}
+
+- (void)addVariant:(Variant *)variant {
+  if (self.variantIdToVariant[variant.identifier]) {
+    [NSException raise:@"Variant has already been added"
+                format:@"A Variant with the idenfier %@ has already been added",
+                       variant.identifier];
+  }
+  for (Mod *m in variant.mods) {
+    if (![self.flagNameToFlag.allKeys containsObject:m.flagName]) {
+      [NSException raise:@"Variant has unknown flag"
+                  format:@"Variant with the idenfier %@ has unknown flag %@",
+                         variant.identifier, m.flagName];
+    }
+    [self.flagNameToVariantIdSet[m.flagName] addObject:variant.identifier];
+  }
+  self.variantIdToVariant[variant.identifier] = variant;
+}
+
+- (NSArray *)allVariants {
+  return [self.variantIdToVariant allValues];
+}
+
+- (void)registerConditionTypeWithId:(NSString *)identifier
+                          specBlock:(ConditionSpec)specBlock {
+  identifier = [identifier uppercaseString];
+  if (self.conditionTypeToSpecBlock[identifier]) {
+    [NSException
+         raise:@"Condition has already been registered"
+        format:@"A Condition with identifier %@ has already been registered",
+               identifier];
+  }
+  self.conditionTypeToSpecBlock[identifier] = specBlock;
+}
+
+- (void)loadConfigFromData:(NSData *)data error:(NSError **)error {
+  NSDictionary *config =
+      [NSJSONSerialization JSONObjectWithData:data options:0 error:error];
+  if (!config) {
+    return;
+  }
+  [self loadConfigFromDictionary:config];
+}
+
+- (void)loadConfigFromDictionary:(NSDictionary *)dictionary {
+  for (NSDictionary *d in dictionary[@"flag_defs"]) {
+    [self addFlag:[Flag flagFromDictionary:d]];
+  }
+  for (NSDictionary *d in dictionary[@"variants"]) {
+    [self addVariant:[self _variantFromDictionary:d]];
+  }
+}
+
+#pragma mark - Private methods
+
+- (void)_registerBuiltInConditionTypes {
+  srand48(time(0));
+  ConditionSpec randomSpec = ^ConditionEvaluator(id<NSCopying> value) {
+      if (![(NSObject *)value isKindOfClass:[NSNumber class]] ||
+          [(NSNumber *)value doubleValue] < 0 ||
+          [(NSNumber *)value doubleValue] > 1) {
+        [NSException
+             raise:@"Invalid argument to RANDOM condition type"
+            format:@"The value %@ must be an NSNumber between 0-1", value];
+      }
+      return ^BOOL(id<NSCopying> context) {
+          return drand48() <= [(NSNumber *)value doubleValue];
+      };
+  };
+  [self registerConditionTypeWithId:@"RANDOM" specBlock:randomSpec];
+
+  ConditionSpec rangeSpec = ^ConditionEvaluator(id<NSCopying> value) {
+      NSArray *values = (NSArray *)value;
+      if (!values || values.count != 3) {
+        [NSException
+             raise:@"Invalid argument to MOD_RANGE condition type"
+            format:@"Expected array with key and and two integer range values"];
+      }
+      if (![values[0] isKindOfClass:[NSString class]]) {
+        [NSException raise:@"Invalid argument to MOD_RANGE condition type"
+                    format:@"The first value %@ must be a string", values[0]];
+      }
+      NSString *key = (NSString *)values[0];
+      if (![values[1] isKindOfClass:[NSNumber class]]) {
+        [NSException raise:@"Invalid argument to MOD_RANGE condition type"
+                    format:@"The second value %@ must be a number", values[1]];
+      }
+      NSNumber *rangeBegin = (NSNumber *)values[1];
+
+      if (![values[2] isKindOfClass:[NSNumber class]]) {
+        [NSException raise:@"Invalid argument to MOD_RANGE condition type"
+                    format:@"The third value %@ must be a number", values[2]];
+      }
+      NSNumber *rangeEnd = (NSNumber *)values[2];
+
+      if ([rangeBegin doubleValue] > [rangeEnd doubleValue]) {
+        [NSException raise:@"Invalid argument to MOD_RANGE condition type"
+                    format:@"Start range %@ must be less than end range %@",
+                           rangeBegin, rangeEnd];
+      }
+      return ^BOOL(id<NSCopying> context) {
+          if (![(NSObject *)context isKindOfClass:[NSDictionary class]]) {
+            return NO;
+          }
+          id val = ((NSDictionary *)context)[key];
+          if (![val isKindOfClass:[NSNumber class]]) {
+            return NO;
+          }
+          NSInteger mod = [(NSNumber *)val integerValue] % 100;
+          return mod >= rangeBegin.integerValue && mod <= rangeEnd.integerValue;
+      };
+  };
+  [self registerConditionTypeWithId:@"MOD_RANGE" specBlock:rangeSpec];
+}
+
+- (Variant *)_variantFromDictionary:(NSDictionary *)dictionary {
+  NSMutableArray *conditions = [NSMutableArray array];
+  for (NSDictionary *d in dictionary[@"conditions"]) {
+    NSString *type = [d[@"type"] uppercaseString];
+    ConditionSpec spec = self.conditionTypeToSpecBlock[type];
+    if (!spec) {
+      [NSException
+           raise:@"Unregistered condition type"
+          format:@"The condition type %@ has not been registered", type];
+    }
+    id<NSCopying> value = d[@"value"];
+    NSArray *values = d[@"values"];
+    if (value && values) {
+      [NSException
+           raise:@"Invalid Variant specification"
+          format:@"Cannot specify both a value and array of values for %@",
+                 type];
+    }
+    ConditionEvaluator evaluator = value ? spec(value) : spec(values);
+    [conditions
+        addObject:[[Condition alloc] initWithEvaluationBlock:evaluator]];
+  }
+  NSMutableArray *mods = [NSMutableArray array];
+  for (NSDictionary *d in dictionary[@"mods"]) {
+    [mods addObject:[Mod modFromDictionary:d]];
+  }
+  return [[Variant alloc] initWithIdentifier:dictionary[@"id"]
+                                          op:dictionary[@"condition_operator"]
+                                  conditions:conditions
+                                        mods:mods];
+}
+
+#pragma mark - Test helpers
+
++ (void)_setSharedRegistry:(Registry *)registry {
+  if (registry == nil) {
+    onceToken = 0;
+  }
+  _sharedRegistry = registry;
+}
+
+@end

--- a/ios/Variants/Variant.h
+++ b/ios/Variants/Variant.h
@@ -1,0 +1,26 @@
+//
+//  Variant.h
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/18/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface Variant : NSObject
+
+- (instancetype)initWithIdentifier:(NSString *)identifier
+                                op:(NSString *)op
+                        conditions:(NSArray *)conditions
+                              mods:(NSArray *)mods;
+
+- (id)valueForFlagWithName:(NSString *)name;
+- (BOOL)evaluateWithContext:(id<NSCopying>)context;
+
+@property(nonatomic, copy, readonly) NSString *identifier;
+@property(nonatomic, copy, readonly) NSString *op;
+@property(nonatomic, copy, readonly) NSArray *conditions;
+@property(nonatomic, copy, readonly) NSArray *mods;
+
+@end

--- a/ios/Variants/Variant.m
+++ b/ios/Variants/Variant.m
@@ -1,0 +1,76 @@
+//
+//  Variant.m
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/18/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+#import "Variant.h"
+
+#import "Condition.h"
+#import "Mod.h"
+
+NSString *const VariantOperatorAND = @"AND";
+NSString *const VariantOperatorOR = @"OR";
+
+@implementation Variant
+
+- (instancetype)initWithIdentifier:(NSString *)identifier
+                                op:(NSString *)op
+                        conditions:(NSArray *)conditions
+                              mods:(NSArray *)mods {
+  self = [super init];
+  if (self) {
+    if ((op && conditions.count < 2) || (!op && conditions.count >= 2)) {
+      [NSException raise:@"Invalid arguments to Variant initializer"
+                  format:op ? @"Cannot have a Variant operator "
+                             @"without multiple conditions"
+                            : @"Cannot have multiple variant "
+                             @"conditions without an operator"];
+    }
+    if (op && (![op isEqualToString:VariantOperatorAND] &&
+               ![op isEqualToString:VariantOperatorOR])) {
+      [NSException
+           raise:@"Invalid operator passed to Variant initializer"
+          format:@"Expected operator to be \"AND\" or \"OR\", got \"%@\"", op];
+    }
+
+    _identifier = [identifier copy];
+    _op = [op copy];
+    _conditions = [conditions copy];
+    _mods = [mods copy];
+  }
+  return self;
+}
+
+- (id)valueForFlagWithName:(NSString *)name {
+  for (Mod *m in self.mods) {
+    if ([m.flagName isEqualToString:name]) {
+      return m.value;
+    }
+  }
+  return nil;
+}
+
+- (BOOL)evaluateWithContext:(id<NSCopying>)context {
+  if ([self.op isEqualToString:VariantOperatorOR]) {
+    for (Condition *c in self.conditions) {
+      if (c.evaluationBlock(context)) {
+        return YES;
+      }
+    }
+    return NO;
+  } else if (self.conditions.count <= 1 ||
+             [self.op isEqualToString:VariantOperatorAND]) {
+    for (Condition *c in self.conditions) {
+      if (!c.evaluationBlock(context)) {
+        return NO;
+      }
+    }
+    return YES;
+  }
+  return NO;
+}
+
+@end

--- a/ios/VariantsTests/Info.plist
+++ b/ios/VariantsTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.andybons.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ios/VariantsTests/VariantsTest.m
+++ b/ios/VariantsTests/VariantsTest.m
@@ -1,0 +1,158 @@
+//
+//  RegistryTest.m
+//  Variants
+//
+//  Created by Andrew Bonventre on 12/18/14.
+//  Copyright (c) 2014 Andrew Bonventre. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "Condition.h"
+#import "Flag.h"
+#import "Mod.h"
+#import "Registry.h"
+#import "Registry+Testing.h"
+#import "Variant.h"
+
+@interface VariantsRegistryTest : XCTestCase
+
+@end
+
+@implementation VariantsRegistryTest
+
+- (void)setUp {
+  [Registry _setSharedRegistry:nil];
+  [super setUp];
+}
+
+- (void)loadConfigFile:(NSString *)filename {
+  Registry *registry = [Registry sharedRegistry];
+  NSError *error;
+  NSString *filePath =
+      [[NSBundle bundleForClass:[self class]] pathForResource:filename
+                                                       ofType:nil];
+  [registry loadConfigFromData:[NSData dataWithContentsOfFile:filePath]
+                         error:&error];
+  XCTAssertNil(error);
+}
+
+- (void)testRegistrySingleton {
+  XCTAssertNotNil([Registry sharedRegistry]);
+  XCTAssertEqualObjects([Registry sharedRegistry], [Registry sharedRegistry]);
+}
+
+- (void)testErrorConditions {
+  NSDictionary *config = @{
+    @"variants" : @[
+      @{
+        @"id" : @"Fail",
+        @"condition_operator" : @"AND",
+        @"conditions" : @[
+          @{@"type" : @"RANDOM", @"value" : @"foo", @"values" : @[ @"foo" ]}
+        ],
+        @"mods" : @[ @{@"flag" : @"foo", @"value" : @"bar"} ]
+      }
+    ]
+  };
+  XCTAssertThrows([[Registry sharedRegistry] loadConfigFromDictionary:config]);
+}
+
+- (void)testRandom {
+  [self loadConfigFile:@"testdata.json"];
+  Registry *registry = [Registry sharedRegistry];
+  NSNumber *val = [registry flagValueWithName:@"always_passes"];
+  XCTAssertTrue(val.boolValue);
+  val = [registry flagValueWithName:@"always_fails"];
+  XCTAssertFalse(val.boolValue);
+}
+
+- (void)testModRange {
+  [self loadConfigFile:@"testdata.json"];
+  Registry *registry = [Registry sharedRegistry];
+  NSNumber *val =
+      [registry flagValueWithName:@"mod_range" context:@{
+        @"user_id" : @0
+      }];
+  XCTAssertTrue(val.boolValue);
+  val = [registry flagValueWithName:@"mod_range" context:@{ @"user_id" : @3 }];
+  XCTAssertTrue(val.boolValue);
+  val = [registry flagValueWithName:@"mod_range" context:@{ @"user_id" : @9 }];
+  XCTAssertTrue(val.boolValue);
+  val = [registry flagValueWithName:@"mod_range" context:@{ @"user_id" : @50 }];
+  XCTAssertFalse(val.boolValue);
+}
+
+- (void)testOperators {
+  [self loadConfigFile:@"testdata.json"];
+  Registry *registry = [Registry sharedRegistry];
+  NSNumber *val = [registry flagValueWithName:@"or_result"
+                                      context:[NSNumber numberWithBool:YES]];
+  XCTAssertTrue(val.boolValue);
+  val = [registry flagValueWithName:@"and_result"
+                            context:[NSNumber numberWithBool:NO]];
+  XCTAssertFalse(val.boolValue);
+}
+
+- (void)testNoOperators {
+  XCTAssertThrowsSpecificNamed(
+      [self loadConfigFile:@"broken_nooperator.json"], NSException,
+      @"Invalid arguments to Variant initializer",
+      @"Cannot have multiple variant conditions without an operator");
+}
+
+- (void)testNoCondition {
+  XCTAssertThrowsSpecificNamed(
+      [self loadConfigFile:@"broken_nocondition.json"], NSException,
+      @"Invalid arguments to Variant initializer",
+      @"Cannot have a Variant operator without multiple conditions");
+}
+
+- (void)testCustomCondition {
+  Registry *registry = [Registry sharedRegistry];
+  [registry
+      registerConditionTypeWithId:@"CUSTOM"
+                        specBlock:^ConditionEvaluator(id<NSCopying> value) {
+                            return ^BOOL(id<NSCopying> context) {
+                                return [((NSDictionary *)context)[@"password"]
+                                    isEqualToString:(NSString *)value];
+                            };
+                        }];
+  [self loadConfigFile:@"custom.json"];
+  NSNumber *val = [registry flagValueWithName:@"custom_value" context:@{}];
+  XCTAssertEqual(val.integerValue, 0);
+  val = [registry flagValueWithName:@"custom_value"
+                            context:@{
+                              @"password" : @"wrong"
+                            }];
+  XCTAssertEqual(val.integerValue, 0);
+  val = [registry flagValueWithName:@"custom_value"
+                            context:@{
+                              @"password" : @"secret"
+                            }];
+  XCTAssertEqual(val.integerValue, 42);
+}
+
+- (void)testGetFlags {
+  [self loadConfigFile:@"testdata.json"];
+  NSArray *allFlags = [[Registry sharedRegistry] allFlags];
+  XCTAssertTrue([allFlags containsObject:@"always_passes"]);
+  XCTAssertTrue([allFlags containsObject:@"always_fails"]);
+  XCTAssertTrue([allFlags containsObject:@"coin_flip"]);
+  XCTAssertTrue([allFlags containsObject:@"mod_range"]);
+}
+
+- (void)testGetVariants {
+  [self loadConfigFile:@"testdata.json"];
+  Variant *variant;
+  for (Variant *v in [[Registry sharedRegistry] allVariants]) {
+    if ([v.identifier isEqualToString:@"CoinFlipTest"]) {
+      variant = v;
+      break;
+    }
+  }
+  XCTAssertNotNil(variant);
+}
+
+@end

--- a/ios/VariantsTests/altdata.json
+++ b/ios/VariantsTests/altdata.json
@@ -1,0 +1,46 @@
+{
+  "flag_defs": [
+    {
+      "flag": "always_passes",
+      "desc": "Always passes (but not really)",
+      "base_value": false
+    },
+    {
+      "flag": "always_fails",
+      "desc": "Always fails (but not really)",
+      "base_value": false
+    }
+  ],
+  "variants": [
+    {
+      "id": "BackwardsAlwaysFailsTest",
+      "conditions": [
+        {
+          "type": "RANDOM",
+          "value": 1.0
+        }
+      ],
+      "mods": [
+        {
+          "flag": "always_fails",
+          "value": true
+        }
+      ]
+    },
+    {
+      "id": "BackwardsAlwaysPassesTest",
+      "conditions": [
+        {
+          "type": "RANDOM",
+          "value": 0.0
+        }
+      ],
+      "mods": [
+        {
+          "flag": "always_passes",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/ios/VariantsTests/broken_nocondition.json
+++ b/ios/VariantsTests/broken_nocondition.json
@@ -1,0 +1,20 @@
+{
+  "flag_defs": [
+    {
+      "flag": "broken",
+      "base_value": false
+    }
+  ],
+  "variants": [
+    {
+      "id": "BrokenNoCondition",
+      "condition_operator": "AND",
+      "mods": [
+        {
+          "flag": "broken",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/ios/VariantsTests/broken_nooperator.json
+++ b/ios/VariantsTests/broken_nooperator.json
@@ -1,0 +1,29 @@
+{
+  "flag_defs": [
+    {
+      "flag": "broken",
+      "base_value": false
+    }
+  ],
+  "variants": [
+    {
+      "id": "BrokenNoOperator",
+      "conditions": [
+        {
+          "type": "RANDOM",
+          "value": 0.0
+        },
+        {
+          "type": "RANDOM",
+          "value": 1.0
+        }
+      ],
+      "mods": [
+        {
+          "flag": "broken",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/ios/VariantsTests/custom.json
+++ b/ios/VariantsTests/custom.json
@@ -1,0 +1,25 @@
+{
+  "flag_defs": [
+    {
+      "flag": "custom_value",
+      "base_value": 0
+    }
+  ],
+  "variants": [
+    {
+      "id": "CustomTest",
+      "conditions": [
+        {
+          "type": "CUSTOM",
+          "value": "secret"
+        }
+      ],
+      "mods": [
+        {
+          "flag": "custom_value",
+          "value": 42
+        }
+      ]
+    }
+  ]
+}

--- a/ios/VariantsTests/testdata.json
+++ b/ios/VariantsTests/testdata.json
@@ -1,0 +1,136 @@
+{
+  "flag_defs": [
+    {
+      "flag": "always_passes",
+      "desc": "Always passes",
+      "base_value": false
+    },
+    {
+      "flag": "always_fails",
+      "desc": "Always fails",
+      "base_value": false
+    },
+    {
+      "flag": "coin_flip",
+      "base_value": false
+    },
+    {
+      "flag": "mod_range",
+      "base_value": false
+    },
+    {
+      "flag": "or_result",
+      "base_value": false
+    },
+    {
+      "flag": "and_result",
+      "base_value": false
+    }
+  ],
+  "variants": [
+    {
+      "id": "AlwaysFailsTest",
+      "conditions": [
+        {
+          "type": "RANDOM",
+          "value": 0.0
+        }
+      ],
+      "mods": [
+        {
+          "flag": "always_fails",
+          "value": true
+        }
+      ]
+    },
+    {
+      "id": "AlwaysPassesTest",
+      "conditions": [
+        {
+          "type": "RANDOM",
+          "value": 1.0
+        }
+      ],
+      "mods": [
+        {
+          "flag": "always_passes",
+          "value": true
+        }
+      ]
+    },
+    {
+      "id": "CoinFlipTest",
+      "conditions": [
+        {
+          "type": "RANDOM",
+          "value": 0.5
+        }
+      ],
+      "mods": [
+        {
+          "flag": "coin_flip",
+          "value": true
+        }
+      ]
+    },
+    {
+      "id": "ModRangeTest",
+      "conditions": [
+        {
+          "type": "MOD_RANGE",
+          "values": [
+            "user_id",
+            0,
+            9
+          ]
+        }
+      ],
+      "mods": [
+        {
+          "flag": "mod_range",
+          "value": true
+        }
+      ]
+    },
+    {
+      "id": "OrTest",
+      "condition_operator": "OR",
+      "conditions": [
+        {
+          "type": "RANDOM",
+          "value": 0.0
+        },
+        {
+          "type": "RANDOM",
+          "value": 1.0
+        }
+      ],
+      "mods": [
+        {
+          "flag": "or_result",
+          "value": true
+        }
+      ]
+    },
+    {
+      "id": "AndTest",
+      "condition_operator": "AND",
+      "conditions": [
+        {
+          "type": "RANDOM",
+          "value": 0.0
+        },
+        {
+          "type": "RANDOM",
+          "value": 1.0
+        }
+      ],
+      "mods": [
+        {
+          "flag": "and_result",
+          "value": true
+        }
+      ]
+    }
+  ]
+}

--- a/ios/VariantsTests/testdata_reloaded.json
+++ b/ios/VariantsTests/testdata_reloaded.json
@@ -1,0 +1,22 @@
+{
+  "flag_defs": [
+    {
+      "flag": "always_passes",
+      "desc": "Always passes",
+      "base_value": true
+    },
+    {
+      "flag": "always_fails",
+      "desc": "Always fails",
+      "base_value": true
+    },
+    {
+      "flag": "coin_flip",
+      "base_value": true
+    },
+    {
+      "flag": "mod_range",
+      "base_value": true
+    }
+  ]
+}

--- a/nodejs/lib/variants.js
+++ b/nodejs/lib/variants.js
@@ -571,7 +571,7 @@ function registerBuiltInConditionTypes() {
     }
   })
 
-  // Register the UMOD_RANGE condition type.
+  // Register the MOD_RANGE condition type.
   registerConditionType('MOD_RANGE', function (values) {
     if (values.length != 3) {
       throw new Error('Expected two integer range values in "values" array')


### PR DESCRIPTION
Happy Holidays Medium Team! :christmas_tree: I got you something shiny... that, uh, I need for my own stuff. I’m so selfless I know.

I say WIP because I’d like to start a discussion given that...
- I don’t know Medium’s class prefixing rules, style guide (though I hope it’s compatible with clang-format), or documentation requirements for iOS.
- I don’t know what to put at the top of files :). Right now it’s just the boilerplate that Xcode spews out.
- I’ve resorted to raising exceptions in the cases where an error would be thrown in Node or returned in Go. I‘m not so sure that all cases qualify as being truly exceptional (is loading a badly formed JSON definition an exceptional condition?). No doubt that if they remain, that users would have to wrap the calls that load the config in try/catch blocks. Seems kinda gnarly to me, but consistency with Medium’s current iOS code trumps personal opinion on the matter.
- The library is _not_ threadsafe (in fact, neither is the Go version). It should be.
- It currently requires the user to implement named registries.
- A Podfile, README, and other loose ends need to be written once the above points are dealt with.

It would be great to get feedback on the API. Right now the code relies very heavily on runtime type checks and casting (perhaps unavoidably). Please include any other members of the iOS team as you see appropriate.

@kocodude @thedrick
